### PR TITLE
Update name of the skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A CloudHealth account and an [api key](https://github.com/CloudHealth/cht_api_gu
 None.
 ```yaml
 skills:
-  - name: aws-billing
+  - name: cloudhealth
     # Required
     chapi-key: ABCDEF123456789  # Cloud Health API key for billing alerts
     # Optional


### PR DESCRIPTION
As pointed by Amit in gitter the readme has an incorrect yaml configuration. The name should be cloudhealth in order to get opsdroid to install this repo. 

This PR fixes the name issue and should allow opsdroid to install this skill without any issues.